### PR TITLE
Fix parsing of cosmetic items

### DIFF
--- a/src/components/analyzeModal/getCosmeticMatrixItemsFromSaveFile.ts
+++ b/src/components/analyzeModal/getCosmeticMatrixItemsFromSaveFile.ts
@@ -1,29 +1,19 @@
 import type { SaveFile } from 'drg-save-parser';
 import { CosmeticMatrixItems } from 'data/cosmetics';
-import { Miner } from 'data/miner';
+import { Miner, MinerIDs } from 'data/miner';
 import { CosmeticMatrixItemEntry } from 'db/AppDatabase';
+import { flipObject } from 'utils/object';
 
 export const getCosmeticMatrixItemFromSaveFile = ({
   SchematicSave: {
-    SchematicSave: {
-      ForgedSchematics: forgedSchematics,
-      OwnedSchematics: unforgedSchematics,
-    },
+    SchematicSave: { OwnedSchematics: unforgedSchematics },
   },
+  CharacterSaves,
 }: SaveFile): CosmeticMatrixItemEntry[] => {
   const acquiredCosmeticMatrixItem: CosmeticMatrixItemEntry[] = [];
   CosmeticMatrixItems.forEach((item) => {
     for (const miner of Object.values(Miner)) {
-      if (
-        forgedSchematics !== undefined &&
-        forgedSchematics.some((f) => item.matrixCoreIds[miner] === f)
-      ) {
-        acquiredCosmeticMatrixItem.push({
-          miner: miner as Miner,
-          name: item.name,
-          isForged: true,
-        });
-      }
+      // unforged cosmetic matrix cores
       if (
         unforgedSchematics !== undefined &&
         unforgedSchematics.some((f) => item.matrixCoreIds[miner] === f)
@@ -36,5 +26,39 @@ export const getCosmeticMatrixItemFromSaveFile = ({
       }
     }
   });
+
+  // We can't just check ForgedSchematics from the save file, since you could
+  // get past season cosmetic items through the performance pass and not
+  // from matrix cores like you would when you get them after the season ends.
+  // This way they dont show up in ForgedSchematics and we can just check if a
+  // player has the cosmetic item available to them. This will cover both cases
+  // of getting them through the performance pass and cosmetic matrix cores.
+  for (const {
+    Vanity: {
+      CharacterVanitySave: { UnLockedVanityItemIDs: unlockedVanityItemIds },
+    },
+    SavegameID: minerId,
+  } of CharacterSaves) {
+    const miner = flipObject(MinerIDs)[minerId];
+    for (const itemId of unlockedVanityItemIds) {
+      CosmeticMatrixItems.filter((item) => item.id === itemId).forEach(
+        (item) => {
+          // avoid duplicates
+          if (
+            !acquiredCosmeticMatrixItem.some(
+              (entry) => entry.name === item.name && entry.miner === miner
+            )
+          ) {
+            acquiredCosmeticMatrixItem.push({
+              miner: miner,
+              name: item.name,
+              isForged: true,
+            });
+          }
+        }
+      );
+    }
+  }
+
   return acquiredCosmeticMatrixItem;
 };


### PR DESCRIPTION
Previously, we checked forgedSchematics in the savefile to find out if a player has unlocked a cosmetic. Past season cosmetics could be obtained through their seasons performance pass though and if you unlock a cosmetic this way, it wont show up in forgedSchematics (because you didnt actually 'forge' it).

Now, we check the Vanity section in the savefile to find out if a miner has access to this vanity item.

This resolves #91.