### PR TITLE
Fix miner progress for weapon paintjobs

### DIFF
--- a/src/pages/weaponPaintjobs/WeaponPaintjobsPage.tsx
+++ b/src/pages/weaponPaintjobs/WeaponPaintjobsPage.tsx
@@ -17,6 +17,7 @@ export default function WeaponPaintjobPage() {
     const acquiredMatrixPaintjobs = await db.matrixWeaponPaintjobs
       .where('miner')
       .anyOf(miner)
+      .filter((paintjob) => paintjob.isForged)
       .count();
     const acquiredUniquePaintjobs = await db.uniqueWeaponPaintjobs
       .where('weapon')


### PR DESCRIPTION
The progress for a miner on the weapon paintjob tab got higher when you have an unforged weapon paintjob. This is inconsistent with the other tabs.

Now, the progress for a miner only gets incremented when you have forged a weapon paintjob.