### PR TITLE
Tab improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,14 @@ export type TabName =
   | 'pickaxes'
   | 'victoryPoses'
   | 'cosmetics'
-  | 'bosco';
+  | 'bosco'
+  | 'matrixCore'
+  | 'cargoCrate'
+  | 'lostPack';
 
 export const DEFAULT_TAB: TabName = 'overclocks';
 
-export const TABS: Array<{
+const CATEGORY_TABS: Array<{
   title: string;
   key: TabName;
   content: React.ComponentType;
@@ -44,13 +47,6 @@ export const TABS: Array<{
     key: 'weaponPaintjobs',
     content: lazy(() => import('pages/weaponPaintjobs/WeaponPaintjobsPage')),
   },
-  // https://github.com/BobertForever/drg-completionist/issues/2
-  // {
-  //   title: "Miner Accessories",
-  //   key: "accessories",
-  //   content: <></>,
-  // },
-  // https://github.com/BobertForever/drg-completionist/issues/3
   {
     title: 'Pickaxes',
     key: 'pickaxes',
@@ -72,6 +68,30 @@ export const TABS: Array<{
     content: lazy(() => import('pages/bosco/BoscoPage')),
   },
 ];
+
+const ORIGIN_TABS: Array<{
+  title: string;
+  key: TabName;
+  content: React.ComponentType;
+}> = [
+  {
+    title: 'Matrix Core',
+    key: 'matrixCore',
+    content: lazy(() => import('pages/origin/MatrixCorePage')),
+  },
+  {
+    title: 'Cargo Crate',
+    key: 'cargoCrate',
+    content: lazy(() => import('pages/origin/CargoCratePage')),
+  },
+  {
+    title: 'Lost Pack',
+    key: 'lostPack',
+    content: lazy(() => import('pages/origin/LostPackPage')),
+  },
+];
+
+export const TABS = [...CATEGORY_TABS, ...ORIGIN_TABS];
 
 const PageSpinner = memo(function PageSpinner() {
   return (

--- a/src/components/PageFooter.tsx
+++ b/src/components/PageFooter.tsx
@@ -2,7 +2,7 @@ import { Layout, Tooltip } from 'antd';
 import { useMemo } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useLocation } from 'react-router-dom';
-import { DEFAULT_TAB, TABS, TabName } from 'App';
+import { DEFAULT_TAB, TabName, TABS } from 'App';
 import { MinerColor } from 'data/miner';
 import './PageFooter.css';
 import useCurrentTabProgress from './useCurrentTabProgress';

--- a/src/components/PageFooter.tsx
+++ b/src/components/PageFooter.tsx
@@ -26,7 +26,7 @@ export default function PageFooter() {
     return [tab, tabName];
   }, [location.pathname]);
 
-  const { progress, partialProgress } = useCurrentTabProgress(currentTab);
+  const { progress, partialProgress, acquiredItems, totalItems } = useCurrentTabProgress(currentTab);
 
   const isFooterHidden = useMemo(
     () => progress === 0 && (partialProgress === null || partialProgress === 0),
@@ -113,7 +113,7 @@ export default function PageFooter() {
             }
             trigger={isMobile ? 'click' : 'hover'}
           >
-            {currentTabDisplayName} Progress: {progress}%
+            {currentTabDisplayName} Progress: {progress}% ({acquiredItems}/{totalItems})
           </Tooltip>
         </div>
       </div>

--- a/src/components/progressCard/ProgressCard.tsx
+++ b/src/components/progressCard/ProgressCard.tsx
@@ -15,6 +15,8 @@ export default function ProgressCard(
 
     progress: {
       percentage: number;
+      obtained: number;
+      total: number;
       initialStrokeColor: string;
     };
   } & Omit<CollapsePanelProps, 'key' | 'header'>

--- a/src/components/progressCard/ProgressCardPorgressBar.css
+++ b/src/components/progressCard/ProgressCardPorgressBar.css
@@ -1,5 +1,5 @@
 .ant-progress-text {
-  width: 6em;
+  width: 7em;
 }
 
 .ant-progress {

--- a/src/components/progressCard/ProgressCardPorgressBar.css
+++ b/src/components/progressCard/ProgressCardPorgressBar.css
@@ -1,0 +1,8 @@
+.ant-progress-text {
+  width: 6em;
+}
+
+.ant-progress {
+  display: flex;
+  align-items: center;
+}

--- a/src/components/progressCard/ProgressCardProgressBar.tsx
+++ b/src/components/progressCard/ProgressCardProgressBar.tsx
@@ -1,9 +1,12 @@
 import { Image, Progress, Tooltip } from 'antd';
 import { memo } from 'react';
 import { RockAndStone } from 'assets/other';
+import './ProgressCardPorgressBar.css';
 
 export default memo(function ProgressCardProgressBar(props: {
   percentage: number;
+  obtained: number;
+  total: number;
   initialStrokeColor: string;
 }) {
   return (
@@ -24,7 +27,7 @@ export default memo(function ProgressCardProgressBar(props: {
             />
           </Tooltip>
         ) : (
-          `${percent}%`
+          `${percent}% (${props.obtained}/${props.total})`
         )
       }
     />

--- a/src/components/useCurrentTabProgress.ts
+++ b/src/components/useCurrentTabProgress.ts
@@ -67,7 +67,7 @@ function getAmountLostPackItems(): number {
       .flat()
       .filter((p) => p.itemSource === ItemSource.LostPack).length +
     BoscoPaintjobs.filter((p) => p.itemSource === ItemSource.LostPack).length + 
-    Pickaxes.filter((p) => p.source === ItemSource.LostPack).length * 6 + UniqueParts.length
+    Pickaxes.filter((p) => p.itemSource === ItemSource.LostPack).length * 6 + UniqueParts.length
   );
 }
 
@@ -132,7 +132,7 @@ async function getAmountAcquiredLostPackItems(
     .and((p) => p.part === 'Paintjob')
     .toArray();
   const lostPackPickaxePaintjobs = Pickaxes.filter(
-    (p) => p.source === ItemSource.LostPack
+    (p) => p.itemSource === ItemSource.LostPack
   ).map((p) => p.name);
   const acquiredLostPackPickaxePaintjobs = acquiredPickaxePaintjobs.filter(
     (p) => lostPackPickaxePaintjobs.includes(p.name)
@@ -149,7 +149,7 @@ async function getAmountAcquiredLostPackItems(
     .and((p) => p.part !== 'Paintjob')
     .toArray();
 
-  const lostPackPickaxeParts = Pickaxes.filter((p) => p.source === ItemSource.LostPack).map((p) => p.name);
+  const lostPackPickaxeParts = Pickaxes.filter((p) => p.itemSource === ItemSource.LostPack).map((p) => p.name);
   const acquiredLostPackPickaxeParts = acquiredPickaxeParts.filter((p) => lostPackPickaxeParts.includes(p.name)).length;
 
   return (

--- a/src/components/useCurrentTabProgress.ts
+++ b/src/components/useCurrentTabProgress.ts
@@ -209,7 +209,6 @@ export default function useCurrentTabProgress(
   currentTab: TabName
 ): TabProgress {
   const db = useDB();
-  getAmountCargoCrateItems;
   const totalItems = useMemo(() => {
     switch (currentTab) {
       case 'frameworks':
@@ -281,7 +280,7 @@ export default function useCurrentTabProgress(
               (acquiredOverclocks.filter((o) => !o.isForged).length /
                 totalItems) *
               100,
-            acquiredItems: acquiredOverclocks,
+            acquiredItems: acquiredOverclocks.length,
             totalItems: totalItems,
           };
         }
@@ -369,6 +368,8 @@ export default function useCurrentTabProgress(
               (acquiredCosmetics.filter((item) => !item.isForged).length /
                 totalItems) *
               100,
+              acquiredItems: acquiredCosmetics.length,
+              totalItems: totalItems,
           };
         }
         case 'bosco': {
@@ -436,7 +437,7 @@ export default function useCurrentTabProgress(
   return {
     progress: Math.floor(p.progress),
     partialProgress:
-      p.partialProgress === null ? null : Math.round(p.partialProgress),
+      p.partialProgress === null ? null : Math.floor(p.partialProgress),
     acquiredItems: p.acquiredItems,
     totalItems: p.totalItems,
   };

--- a/src/components/useCurrentTabProgress.ts
+++ b/src/components/useCurrentTabProgress.ts
@@ -437,7 +437,7 @@ export default function useCurrentTabProgress(
   return {
     progress: Math.floor(p.progress),
     partialProgress:
-      p.partialProgress === null ? null : Math.floor(p.partialProgress),
+      p.partialProgress === null ? null : Math.ceil(p.partialProgress),
     acquiredItems: p.acquiredItems,
     totalItems: p.totalItems,
   };

--- a/src/components/useCurrentTabProgress.ts
+++ b/src/components/useCurrentTabProgress.ts
@@ -9,8 +9,10 @@ import { Miner } from 'data/miner';
 import { Overclocks } from 'data/overclocks';
 import {
   PickaxePaintjobNames,
+  Pickaxes,
   PickaxeSets,
   PickaxeUniquePartNames,
+  UniqueParts,
 } from 'data/pickaxes';
 import { CommonVictoryPoses, MatrixVictoryPoses } from 'data/victoryPoses';
 import {
@@ -19,18 +21,195 @@ import {
   UniqueWeaponPaintjobs,
 } from 'data/weaponPaintjobs';
 import { MinerWeapons } from 'data/weapons';
+import { AppDatabase } from 'db/AppDatabase';
 import useDB from 'db/useDB';
+import { ItemSource } from 'types/itemSource';
 
 type TabProgress = {
   progress: number;
   partialProgress: number | null;
+  acquiredItems: number;
+  totalItems: number;
 };
+
+function getAmountMatrixCoreItems(): number {
+  return (
+    Object.values(Overclocks)
+      .flatMap((w) => Object.values(w))
+      .flat().length +
+    Object.values(ArmorPaintjobs)
+      .flatMap((w) => Object.values(w))
+      .flat()
+      .filter((paintjob) => paintjob.itemSource === ItemSource.MatrixCore)
+      .length +
+    MatrixWeaponPaintjobs.length * Object.values(Miner).length +
+    Object.values(MatrixVictoryPoses).flatMap((p) => Object.values(p)).length +
+    CosmeticMatrixItems.length * Object.values(Miner).length
+  );
+}
+
+function getAmountCargoCrateItems(): number {
+  return (
+    Object.values(Frameworks)
+      .flat()
+      .filter((f) => f.itemSource === ItemSource.CargoCrate).length +
+    BoscoFrameworks.filter((f) => f.itemSource === ItemSource.CargoCrate)
+      .length +
+    CommonVictoryPoses.filter((v) => v.itemSource === ItemSource.CargoCrate)
+      .length *
+      Object.values(Miner).length
+  );
+}
+
+function getAmountLostPackItems(): number {
+  return (
+    Object.values(ArmorPaintjobs)
+      .flat()
+      .filter((p) => p.itemSource === ItemSource.LostPack).length +
+    BoscoPaintjobs.filter((p) => p.itemSource === ItemSource.LostPack).length + 
+    Pickaxes.filter((p) => p.source === ItemSource.LostPack).length * 6 + UniqueParts.length
+  );
+}
+
+async function getAmountAcquiredCargoCrateItems(
+  db: AppDatabase
+): Promise<number> {
+  const acquiredFrameworks = await db.frameworks.toArray();
+  const cargoCrateFrameworks = Object.values(Frameworks)
+    .flat()
+    .filter((f) => f.itemSource === ItemSource.CargoCrate)
+    .map((f) => f.name);
+  const acquiredCargoCrateFrameworks = acquiredFrameworks.filter((f) =>
+    cargoCrateFrameworks.includes(f.name)
+  ).length;
+
+  const acquiredVictoryPoses = await db.commonVictoryPoses.toArray();
+  const cargoCrateVictoryPoses = CommonVictoryPoses.filter(
+    (v) => v.itemSource === ItemSource.CargoCrate
+  ).map((f) => f.name);
+  const acquiredCargoCrateVictroyPoses = acquiredVictoryPoses.filter((v) =>
+    cargoCrateVictoryPoses.includes(v.name)
+  ).length;
+
+  const acquiredBoscoFrameworks = await db.boscoFrameworks.toArray();
+  const cargoCrateBoscoFrameworks = BoscoFrameworks.filter(
+    (f) => f.itemSource === ItemSource.CargoCrate
+  ).map((f) => f.name);
+  const acquiredCargoCrateBoscoFrameworks = acquiredBoscoFrameworks.filter(
+    (f) => cargoCrateBoscoFrameworks.includes(f.name)
+  ).length;
+
+  return (
+    acquiredCargoCrateFrameworks +
+    acquiredCargoCrateVictroyPoses +
+    acquiredCargoCrateBoscoFrameworks
+  );
+}
+
+async function getAmountAcquiredLostPackItems(
+  db: AppDatabase
+): Promise<number> {
+  const acquiredArmorPaintjobs = await db.armorPaintjobs.toArray();
+  const lostPackArmorPaintjobs = Object.values(ArmorPaintjobs)
+    .flat()
+    .filter((p) => p.itemSource === ItemSource.LostPack)
+    .map((p) => p.name);
+  const acquiredLostPackArmorPaintjobs = acquiredArmorPaintjobs.filter((p) =>
+    lostPackArmorPaintjobs.includes(p.name)
+  ).length;
+
+  const acquiredBoscoPaintjobs = await db.boscoPaintjobs.toArray();
+  const lostPackBoscoPaintjobs = BoscoPaintjobs.filter(
+    (p) => p.itemSource === ItemSource.LostPack
+  ).map((p) => p.name);
+  const acquiredLostPackBoscoPaintjobs = acquiredBoscoPaintjobs.filter((p) =>
+    lostPackBoscoPaintjobs.includes(p.name)
+  ).length;
+
+  const acquiredPickaxePaintjobs = await db.pickaxes
+    .where('name')
+    .anyOf(PickaxePaintjobNames)
+    .and((p) => p.part === 'Paintjob')
+    .toArray();
+  const lostPackPickaxePaintjobs = Pickaxes.filter(
+    (p) => p.source === ItemSource.LostPack
+  ).map((p) => p.name);
+  const acquiredLostPackPickaxePaintjobs = acquiredPickaxePaintjobs.filter(
+    (p) => lostPackPickaxePaintjobs.includes(p.name)
+  ).length;
+
+  const acquiredUniquePickaxeParts = await db.pickaxeUniques
+    .where('name')
+    .anyOf(PickaxeUniquePartNames)
+    .count();
+
+  const acquiredPickaxeParts = await db.pickaxes
+    .where('name')
+    .anyOf(PickaxeSets)
+    .and((p) => p.part !== 'Paintjob')
+    .toArray();
+
+  const lostPackPickaxeParts = Pickaxes.filter((p) => p.source === ItemSource.LostPack).map((p) => p.name);
+  const acquiredLostPackPickaxeParts = acquiredPickaxeParts.filter((p) => lostPackPickaxeParts.includes(p.name)).length;
+
+  return (
+    acquiredLostPackArmorPaintjobs +
+    acquiredLostPackBoscoPaintjobs +
+    acquiredLostPackPickaxePaintjobs +
+    acquiredUniquePickaxeParts +
+    acquiredLostPackPickaxeParts
+  );
+}
+
+async function getAmountAcquiredMatrixCoreItems(
+  db: AppDatabase
+): Promise<[number, number]> {
+  const acquiredOverclocks = await db.overclocks.toArray();
+  const matrixCoresForged = acquiredOverclocks.filter((o) => o.isForged).length;
+  const matrixCoresUnforged = acquiredOverclocks.filter((o) => !o.isForged)
+    .length;
+
+  const acquiredMatrixPaintjobs = await db.matrixWeaponPaintjobs.toArray();
+  const weaponPaintjobsForged = acquiredMatrixPaintjobs.filter(
+    (p) => p.isForged
+  ).length;
+  const weaponPaintjobsUnforged = acquiredMatrixPaintjobs.filter(
+    (p) => !p.isForged
+  ).length;
+
+  const acquiredMatrixVictoryPoses = await db.matrixVictoryPoses.toArray();
+  const victoryPosesForged = acquiredMatrixVictoryPoses.filter(
+    (p) => p.isForged
+  ).length;
+  const victoryPosesUnforged = acquiredMatrixVictoryPoses.filter(
+    (pose) => !pose.isForged
+  ).length;
+
+  const acquiredCosmetics = await db.cosmeticMatrixItems.toArray();
+  const cosmeticsForged = acquiredCosmetics.filter((item) => item.isForged)
+    .length;
+  const cosmeticsUnforged = acquiredCosmetics.filter((item) => !item.isForged)
+    .length;
+
+  const numForged =
+    matrixCoresForged +
+    weaponPaintjobsForged +
+    victoryPosesForged +
+    cosmeticsForged;
+  const numUnforged =
+    matrixCoresUnforged +
+    weaponPaintjobsUnforged +
+    victoryPosesUnforged +
+    cosmeticsUnforged;
+
+  return [numForged, numUnforged];
+}
 
 export default function useCurrentTabProgress(
   currentTab: TabName
 ): TabProgress {
   const db = useDB();
-
+  getAmountCargoCrateItems;
   const totalItems = useMemo(() => {
     switch (currentTab) {
       case 'frameworks':
@@ -70,6 +249,12 @@ export default function useCurrentTabProgress(
         return CosmeticMatrixItems.length * Object.values(Miner).length;
       case 'bosco':
         return BoscoFrameworks.length + BoscoPaintjobs.length;
+      case 'matrixCore':
+        return getAmountMatrixCoreItems();
+      case 'cargoCrate':
+        return getAmountCargoCrateItems();
+      case 'lostPack':
+        return getAmountLostPackItems();
     }
   }, [currentTab]) as number;
 
@@ -81,6 +266,8 @@ export default function useCurrentTabProgress(
           return {
             progress: (acquiredFrameworks / totalItems) * 100,
             partialProgress: null,
+            acquiredItems: acquiredFrameworks,
+            totalItems: totalItems,
           };
         }
         case 'overclocks': {
@@ -94,6 +281,8 @@ export default function useCurrentTabProgress(
               (acquiredOverclocks.filter((o) => !o.isForged).length /
                 totalItems) *
               100,
+            acquiredItems: acquiredOverclocks,
+            totalItems: totalItems,
           };
         }
         case 'armor': {
@@ -105,6 +294,9 @@ export default function useCurrentTabProgress(
                 totalItems) *
               100,
             partialProgress: null,
+            acquiredItems:
+              acquiredArmorPaintjobs + acquiredCommonArmorPaintJobs,
+            totalItems: totalItems,
           };
         }
         case 'weaponPaintjobs': {
@@ -124,6 +316,11 @@ export default function useCurrentTabProgress(
           return {
             progress: progress,
             partialProgress: partialProgress,
+            acquiredItems:
+              acquiredCommonPaintjobs.length +
+              acquiredUniquePaintjobs.length +
+              acquiredMatrixPaintjobs.length,
+            totalItems: totalItems,
           };
         }
         case 'pickaxes': {
@@ -134,6 +331,8 @@ export default function useCurrentTabProgress(
               ((acquiredPickaxeParts + acquiredPickaxeUniques) / totalItems) *
               100,
             partialProgress: null,
+            acquiredItems: acquiredPickaxeParts + acquiredPickaxeUniques,
+            totalItems: totalItems,
           };
         }
         case 'victoryPoses': {
@@ -153,6 +352,10 @@ export default function useCurrentTabProgress(
           return {
             progress: progress,
             partialProgress: partialProgress,
+            acquiredItems:
+              acquiredCommonVictoryPoses.length +
+              acquiredMatrixVictoryPoses.length,
+            totalItems: totalItems,
           };
         }
         case 'cosmetics': {
@@ -177,6 +380,38 @@ export default function useCurrentTabProgress(
                 totalItems) *
               100,
             partialProgress: null,
+            acquiredItems: acquiredBoscoFrameworks + acquiredBoscoPaintjobs,
+            totalItems: totalItems,
+          };
+        }
+        case 'matrixCore': {
+          const [
+            numForged,
+            numUnforged,
+          ] = await getAmountAcquiredMatrixCoreItems(db);
+          return {
+            progress: (numForged / totalItems) * 100,
+            partialProgress: (numUnforged / totalItems) * 100,
+            acquiredItems: numForged + numUnforged,
+            totalItems: totalItems,
+          };
+        }
+        case 'cargoCrate': {
+          const numAcquired = await getAmountAcquiredCargoCrateItems(db);
+          return {
+            progress: (numAcquired / totalItems) * 100,
+            partialProgress: null,
+            acquiredItems: numAcquired,
+            totalItems: totalItems,
+          };
+        }
+        case 'lostPack': {
+          const numAcquired = await getAmountAcquiredLostPackItems(db);
+          return {
+            progress: (numAcquired / totalItems) * 100,
+            partialProgress: null,
+            acquiredItems: numAcquired,
+            totalItems: totalItems,
           };
         }
       }
@@ -185,20 +420,24 @@ export default function useCurrentTabProgress(
     {
       progress: 0,
       partialProgress: null,
+      acquiredItems: 0,
+      totalItems: 0,
     }
-  ) as { progress: number; partialProgress: number };
+  ) as { progress: number; partialProgress: number, acquiredItems: number, totalItems: number };
 
   useEffect(() => {
     gtag('event', `progress`, {
       event_category: 'tab_progress',
       event_label: currentTab,
-      value: Math.round(p.progress),
+      value: Math.floor(p.progress),
     });
   }, [p.progress, currentTab]);
 
   return {
-    progress: Math.round(p.progress),
+    progress: Math.floor(p.progress),
     partialProgress:
       p.partialProgress === null ? null : Math.round(p.partialProgress),
+    acquiredItems: p.acquiredItems,
+    totalItems: p.totalItems,
   };
 }

--- a/src/data/pickaxes.ts
+++ b/src/data/pickaxes.ts
@@ -56,10 +56,7 @@ export const PickaxeIcons: Record<typeof PickaxeSets[number], ImgSrc> = {
 };
 
 // NOTE: DLC Paintjobs disabled until GUIDs can be found
-export const PickaxePaintjobIcons: Record<
-  typeof PickaxePaintjobNames[number],
-  ImgSrc
-> = {
+export const PickaxePaintjobIcons: Record<PickaxePaintjobName, ImgSrc> = {
   'Bug Hide': paintjobIcons.BugHide,
   'Carven Pride': paintjobIcons.CarvenPride,
   'Chasm-Borne Cliffhanger': paintjobIcons.ChasmBorneCliffhanger,
@@ -97,12 +94,14 @@ export type PickaxeParts =
   | 'Pommel'
   | 'Paintjob';
 
+export type PickaxePaintjobName = typeof PickaxePaintjobNames[number];
+
 export type Pickaxe = {
   name: typeof PickaxeSets[number];
   source: ItemSource;
   assignmentRank?: number;
   icon: typeof PickaxeIcons[typeof PickaxeSets[number]];
-  paintjobIcon: typeof PickaxePaintjobIcons[typeof PickaxePaintjobNames[number]];
+  paintjobIcon: typeof PickaxePaintjobIcons[PickaxePaintjobName];
   partIDs: Record<PickaxeParts, string>;
 };
 

--- a/src/data/pickaxes.ts
+++ b/src/data/pickaxes.ts
@@ -98,7 +98,7 @@ export type PickaxePaintjobName = typeof PickaxePaintjobNames[number];
 
 export type Pickaxe = {
   name: typeof PickaxeSets[number];
-  source: ItemSource;
+  itemSource: ItemSource;
   assignmentRank?: number;
   icon: typeof PickaxeIcons[typeof PickaxeSets[number]];
   paintjobIcon: typeof PickaxePaintjobIcons[PickaxePaintjobName];
@@ -115,7 +115,7 @@ export type PickaxeUniquePart = {
 export const Pickaxes: Pickaxe[] = [
   {
     name: 'Chasm-Borne Cliffhanger',
-    source: ItemSource.Assignment,
+    itemSource: ItemSource.Assignment,
     assignmentRank: 20,
     icon: PickaxeIcons['Chasm-Borne Cliffhanger'],
     paintjobIcon: PickaxePaintjobIcons['Chasm-Borne Cliffhanger'],
@@ -130,7 +130,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: "Gadgeteer's Favorite",
-    source: ItemSource.Assignment,
+    itemSource: ItemSource.Assignment,
     assignmentRank: 30,
     icon: PickaxeIcons["Gadgeteer's Favorite"],
     paintjobIcon: PickaxePaintjobIcons["Gadgeteer's Favorite"],
@@ -145,7 +145,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: "Reaper's Claw",
-    source: ItemSource.Assignment,
+    itemSource: ItemSource.Assignment,
     assignmentRank: 50,
     icon: PickaxeIcons["Reaper's Claw"],
     paintjobIcon: PickaxePaintjobIcons["Reaper's Claw"],
@@ -160,7 +160,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: 'Drift Crusher',
-    source: ItemSource.Assignment,
+    itemSource: ItemSource.Assignment,
     assignmentRank: 75,
     icon: PickaxeIcons['Drift Crusher'],
     paintjobIcon: PickaxePaintjobIcons['Drift Crusher'],
@@ -176,7 +176,7 @@ export const Pickaxes: Pickaxe[] = [
 
   {
     name: 'Bug Hide',
-    source: ItemSource.LostPack,
+    itemSource: ItemSource.LostPack,
     icon: PickaxeIcons['Bug Hide'],
     paintjobIcon: PickaxePaintjobIcons['Bug Hide'],
     partIDs: {
@@ -190,7 +190,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: 'Carven Pride',
-    source: ItemSource.LostPack,
+    itemSource: ItemSource.LostPack,
     icon: PickaxeIcons['Carven Pride'],
     paintjobIcon: PickaxePaintjobIcons['Carven Pride'],
     partIDs: {
@@ -205,7 +205,7 @@ export const Pickaxes: Pickaxe[] = [
 
   {
     name: 'Hammerblow',
-    source: ItemSource.LostPack,
+    itemSource: ItemSource.LostPack,
     icon: PickaxeIcons['Hammerblow'],
     paintjobIcon: PickaxePaintjobIcons['Hammerblow'],
     partIDs: {
@@ -219,7 +219,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: 'Incorruptible',
-    source: ItemSource.LostPack,
+    itemSource: ItemSource.LostPack,
     icon: PickaxeIcons['Incorruptible'],
     paintjobIcon: PickaxePaintjobIcons['Incorruptible'],
     partIDs: {
@@ -233,7 +233,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: 'Jagged Son',
-    source: ItemSource.LostPack,
+    itemSource: ItemSource.LostPack,
     icon: PickaxeIcons['Jagged Son'],
     paintjobIcon: PickaxePaintjobIcons['Jagged Son'],
     partIDs: {
@@ -247,7 +247,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: 'Pneumatic',
-    source: ItemSource.LostPack,
+    itemSource: ItemSource.LostPack,
     icon: PickaxeIcons['Pneumatic'],
     paintjobIcon: PickaxePaintjobIcons['Pneumatic'],
     partIDs: {
@@ -261,7 +261,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: "Arc Welder's Delight",
-    source: ItemSource.LostPack,
+    itemSource: ItemSource.LostPack,
     icon: PickaxeIcons["Arc Welder's Delight"],
     paintjobIcon: PickaxePaintjobIcons["Arc Welder's Delight"],
     partIDs: {
@@ -275,7 +275,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: 'Core Hound',
-    source: ItemSource.LostPack,
+    itemSource: ItemSource.LostPack,
     icon: PickaxeIcons['Core Hound'],
     paintjobIcon: PickaxePaintjobIcons['Core Hound'],
     partIDs: {
@@ -289,7 +289,7 @@ export const Pickaxes: Pickaxe[] = [
   },
   {
     name: 'Blight Guard',
-    source: ItemSource.PerformancePass,
+    itemSource: ItemSource.PerformancePass,
     icon: PickaxeIcons['Blight Guard'],
     paintjobIcon: PickaxePaintjobIcons['Blight Guard'],
     partIDs: {

--- a/src/pages/MinerPageLayout.tsx
+++ b/src/pages/MinerPageLayout.tsx
@@ -34,8 +34,7 @@ export default function MinerPageLayout(props: {
       className="unselectable"
       expandIconPosition="right"
       defaultActiveKey={getOpenCategories([...AllMiners], category)}
-      onChange={(open) =>
-        updateOpenCategories(open, [...AllMiners], category)}
+      onChange={(open) => updateOpenCategories(open, [...AllMiners], category)}
       expandIcon={(p) => (
         <RightOutlined
           style={{ marginTop: 16 }}

--- a/src/pages/MinerPageLayout.tsx
+++ b/src/pages/MinerPageLayout.tsx
@@ -1,8 +1,9 @@
 import { RightOutlined } from '@ant-design/icons';
 import { Collapse } from 'antd';
 import { useMemo } from 'react';
-import MinerCard, { ProgressQuery } from 'components/progressCard/MinerCard';
+import MinerCard from 'components/progressCard/MinerCard';
 import { AllMiners, Miner } from 'data/miner';
+import { MinerProgressQuery } from 'types/progress';
 import { getOpenCategories, updateOpenCategories } from 'utils/localStorage';
 
 /**
@@ -17,7 +18,7 @@ export default function MinerPageLayout(props: {
   children:
     | ((miner: Miner) => React.ReactNode)
     | [(miner: Miner) => React.ReactNode, React.ReactNode];
-  getProgress: ProgressQuery;
+  getProgress: MinerProgressQuery;
 }) {
   const { category, children } = props;
 

--- a/src/pages/armor/ArmorPage.tsx
+++ b/src/pages/armor/ArmorPage.tsx
@@ -21,7 +21,10 @@ export default function ArmorPage() {
       .where('miner')
       .anyOf(miner)
       .count();
-    return acquiredPaintjobs / paintjobs.length;
+    return {
+      obtained: acquiredPaintjobs,
+      total: paintjobs.length,
+    };
   }, []);
 
   const db = useDB();
@@ -74,6 +77,8 @@ export default function ArmorPage() {
             percentage:
               (acquiredCommonArmorPaintJobs / CommonArmorPaintjobs.length) *
               100,
+            obtained: acquiredCommonArmorPaintJobs,
+            total: CommonArmorPaintjobs.length,
             initialStrokeColor: '#A8A8A8',
           }}
         >

--- a/src/pages/bosco/BoscoFrameworks.tsx
+++ b/src/pages/bosco/BoscoFrameworks.tsx
@@ -2,8 +2,8 @@ import { Card, Collapse, CollapsePanelProps, Row } from 'antd';
 import { Bosco } from 'assets/bosco';
 import Image from 'components/Image';
 import { BoscoFramework } from 'data/bosco';
+import { ProgressQuery } from 'types/progress';
 import BoscoFrameworkCard from './BoscoFrameworkCard';
-import { ProgressQuery } from './BoscoPage';
 import BoscoProgressBar from './BoscoProgressBar';
 
 const { Panel } = Collapse;

--- a/src/pages/bosco/BoscoPage.tsx
+++ b/src/pages/bosco/BoscoPage.tsx
@@ -12,15 +12,16 @@ import { getOpenCategories, updateOpenCategories } from 'utils/localStorage';
 import BoscoFrameworks from './BoscoFrameworks';
 import BoscoPaintjobs from './BoscoPaintjobs';
 
-export type ProgressQuery = (db: AppDatabase) => Promise<number>;
-
 export default function BoscoPage() {
   const getPaintjobProgress = useCallback(async (db: AppDatabase) => {
     const acquiredPaintjobs = await db.boscoPaintjobs
       .where('name')
       .anyOf(BoscoPaintjobNames)
       .count();
-    return acquiredPaintjobs / BoscoPaintjobsList.length;
+    return {
+      obtained: acquiredPaintjobs,
+      total: BoscoPaintjobsList.length,
+    };
   }, []);
 
   const getFrameworkProgress = useCallback(async (db: AppDatabase) => {
@@ -28,7 +29,10 @@ export default function BoscoPage() {
       .where('name')
       .anyOf(BoscoFrameworkNames)
       .count();
-    return acquiredFrameworks / BoscoFrameworksList.length;
+    return {
+      obtained: acquiredFrameworks,
+      total: BoscoFrameworksList.length,
+    };
   }, []);
 
   const categories = ['bosco-frameworks', 'bosco-paintjobs'];

--- a/src/pages/bosco/BoscoPaintjobs.tsx
+++ b/src/pages/bosco/BoscoPaintjobs.tsx
@@ -2,7 +2,7 @@ import { Card, Collapse, CollapsePanelProps, Row } from 'antd';
 import { Bosco } from 'assets/bosco';
 import Image from 'components/Image';
 import { BoscoPaintjob } from 'data/bosco';
-import { ProgressQuery } from './BoscoPage';
+import { ProgressQuery } from 'types/progress';
 import BoscoPaintjobCard from './BoscoPaintjobCard';
 import BoscoProgressBar from './BoscoProgressBar';
 

--- a/src/pages/bosco/BoscoProgressBar.tsx
+++ b/src/pages/bosco/BoscoProgressBar.tsx
@@ -1,19 +1,20 @@
 import { Image, Progress, Tooltip } from 'antd';
 import { memo } from 'react';
 import { RockAndStone } from 'assets/other';
-import type { AppDatabase } from 'db/AppDatabase';
 import useDB from 'db/useDB';
 import useSuspendedLiveQuery from 'db/useSuspendedLiveQuery';
-
-export type ProgressQuery = (db: AppDatabase) => Promise<number>;
+import { ProgressQuery } from 'types/progress';
 
 export default memo(function BoscoProgressBar(props: {
   barColor: string;
   getProgress: ProgressQuery;
 }) {
   const db = useDB();
-  const progress = useSuspendedLiveQuery(() => props.getProgress(db), []);
-  const progressPercentage = Math.round((progress || 0) * 100);
+  const { obtained, total } = useSuspendedLiveQuery(
+    () => props.getProgress(db),
+    []
+  );
+  const progressPercentage = Math.floor((obtained / total || 0) * 100);
 
   return (
     <Progress

--- a/src/pages/cosmetics/CosmeticsPage.tsx
+++ b/src/pages/cosmetics/CosmeticsPage.tsx
@@ -29,7 +29,10 @@ export default function CosmeticMatrixCoreItemPage() {
       .anyOf(miner)
       .filter((item) => item.isForged)
       .count();
-    return acquiredCosmetics / CosmeticMatrixItems.length;
+    return {
+      obtained: acquiredCosmetics,
+      total: CosmeticMatrixItems.length,
+    };
   }, []);
 
   return (

--- a/src/pages/cosmetics/CosmeticsPage.tsx
+++ b/src/pages/cosmetics/CosmeticsPage.tsx
@@ -46,7 +46,7 @@ export default function CosmeticMatrixCoreItemPage() {
   );
 }
 
-function CosmeticHeadwears(props: { miner: Miner }) {
+export function CosmeticHeadwears(props: { miner: Miner }) {
   return (
     <React.Fragment key={props.miner + '-headwears'}>
       <Divider orientation="center">
@@ -75,7 +75,7 @@ function CosmeticHeadwears(props: { miner: Miner }) {
   );
 }
 
-function CosmeticBeards(props: { miner: Miner }) {
+export function CosmeticBeards(props: { miner: Miner }) {
   return (
     <React.Fragment key={props.miner + '-beards'}>
       <Divider orientation="center">
@@ -104,7 +104,7 @@ function CosmeticBeards(props: { miner: Miner }) {
   );
 }
 
-function CosmeticMoustaches(props: { miner: Miner }) {
+export function CosmeticMoustaches(props: { miner: Miner }) {
   return (
     <React.Fragment key={props.miner + '-moustache'}>
       <Divider orientation="center">
@@ -133,7 +133,7 @@ function CosmeticMoustaches(props: { miner: Miner }) {
   );
 }
 
-function CosmeticSideburns(props: { miner: Miner }) {
+export function CosmeticSideburns(props: { miner: Miner }) {
   return (
     <React.Fragment key={props.miner + '-sideburns'}>
       <Divider orientation="center">

--- a/src/pages/frameworks/FrameworksPage.tsx
+++ b/src/pages/frameworks/FrameworksPage.tsx
@@ -13,7 +13,10 @@ export default function FrameworksPage() {
       .where('weapon')
       .anyOf(weapons)
       .count();
-    return acquiredFrameworks / (FrameworkNames.length * weapons.length);
+    return {
+      obtained: acquiredFrameworks,
+      total: FrameworkNames.length * weapons.length,
+    };
   }, []);
   return (
     <MinerPageLayout category="WeaponFrameworks" getProgress={getProgress}>

--- a/src/pages/origin/CargoCratePage.tsx
+++ b/src/pages/origin/CargoCratePage.tsx
@@ -47,10 +47,10 @@ export default function CargoCratePage() {
         cargoCrateVictoryPoses.includes(v.name)
       ).length;
 
-      return (
-        (acquiredCargoCrateFrameworks + acquiredCargoCrateVictoryPoses) /
-        (cargoCrateFrameworks.length + cargoCrateVictoryPoses.length)
-      );
+      return {
+        obtained: acquiredCargoCrateFrameworks + acquiredCargoCrateVictoryPoses,
+        total: cargoCrateFrameworks.length + cargoCrateVictoryPoses.length,
+      };
     },
     []
   );
@@ -66,7 +66,10 @@ export default function CargoCratePage() {
     const acquiredCargoCrateBoscoFrameworks = acquiredBoscoFrameworks.filter(
       (f) => cargoCrateBoscoFrameworks.includes(f.name)
     ).length;
-    return acquiredCargoCrateBoscoFrameworks / cargoCrateBoscoFrameworks.length;
+    return {
+      obtained: acquiredCargoCrateBoscoFrameworks,
+      total: cargoCrateBoscoFrameworks.length,
+    };
   }, []);
 
   const categories = ['cargo-bosco-frameworks'];

--- a/src/pages/origin/CargoCratePage.tsx
+++ b/src/pages/origin/CargoCratePage.tsx
@@ -1,0 +1,139 @@
+import { RightOutlined } from '@ant-design/icons';
+import { Row, Divider, Collapse } from 'antd';
+import React, { useCallback } from 'react';
+import WeaponDivider from 'components/WeaponDivider';
+import {
+  BoscoFrameworkNames,
+  BoscoFrameworks as BoscoFrameworksList,
+} from 'data/bosco';
+import { Framework, Frameworks } from 'data/frameworks';
+import { Miner } from 'data/miner';
+import { CommonVictoryPoses } from 'data/victoryPoses';
+import { MinerWeapons } from 'data/weapons';
+import { AppDatabase } from 'db/AppDatabase';
+import MinerPageLayout from 'pages/MinerPageLayout';
+import BoscoFrameworks from 'pages/bosco/BoscoFrameworks';
+import FrameworkCard from 'pages/frameworks/FrameworkCard';
+import CommonVictoryPoseCard from 'pages/victoryPoses/CommonVictoryPosesCard';
+import { ItemSource } from 'types/itemSource';
+import { getOpenCategories, updateOpenCategories } from 'utils/localStorage';
+
+export default function CargoCratePage() {
+  const getCargoCrateProgress = useCallback(
+    async (db: AppDatabase, miner: Miner) => {
+      const weapons = MinerWeapons[miner as Miner];
+      const acquiredFrameworks = await db.frameworks
+        .where('weapon')
+        .anyOf(weapons)
+        .toArray();
+      const minerCargoCrateFrameworks: Framework[] = weapons
+        .map((w) => Frameworks[w])
+        .flat();
+      const cargoCrateFrameworks = minerCargoCrateFrameworks
+        .filter((f) => f.itemSource === ItemSource.CargoCrate)
+        .map((f) => f.name);
+      const acquiredCargoCrateFrameworks = acquiredFrameworks.filter((f) =>
+        cargoCrateFrameworks.includes(f.name)
+      ).length;
+
+      const acquiredVictoryPoses = await db.commonVictoryPoses
+        .where('miner')
+        .anyOf(miner)
+        .toArray();
+      const cargoCrateVictoryPoses = CommonVictoryPoses.filter(
+        (v) => v.itemSource === ItemSource.CargoCrate
+      ).map((v) => v.name);
+      const acquiredCargoCrateVictoryPoses = acquiredVictoryPoses.filter((v) =>
+        cargoCrateVictoryPoses.includes(v.name)
+      ).length;
+
+      return (
+        (acquiredCargoCrateFrameworks + acquiredCargoCrateVictoryPoses) /
+        (cargoCrateFrameworks.length + cargoCrateVictoryPoses.length)
+      );
+    },
+    []
+  );
+
+  const getBoscoFrameworkProgress = useCallback(async (db: AppDatabase) => {
+    const acquiredBoscoFrameworks = await db.boscoFrameworks
+      .where('name')
+      .anyOf(BoscoFrameworkNames)
+      .toArray();
+    const cargoCrateBoscoFrameworks = BoscoFrameworksList.filter(
+      (f) => f.itemSource === ItemSource.CargoCrate
+    ).map((f) => f.name);
+    const acquiredCargoCrateBoscoFrameworks = acquiredBoscoFrameworks.filter(
+      (f) => cargoCrateBoscoFrameworks.includes(f.name)
+    ).length;
+    return acquiredCargoCrateBoscoFrameworks / cargoCrateBoscoFrameworks.length;
+  }, []);
+
+  const categories = ['cargo-bosco-frameworks'];
+
+  return (
+    <>
+      <MinerPageLayout
+        category="CargoCrates"
+        getProgress={getCargoCrateProgress}
+      >
+        {(miner) => (
+          <>
+            {MinerWeapons[miner].map((weapon) => (
+              <React.Fragment key={weapon}>
+                <WeaponDivider weapon={weapon} />
+                <Row gutter={[16, 16]}>
+                  {Frameworks[weapon]
+                    .filter((f) => f.itemSource === ItemSource.CargoCrate)
+                    .map((framework) => (
+                      <FrameworkCard
+                        key={framework.name}
+                        miner={miner}
+                        weapon={weapon}
+                        framework={framework}
+                      />
+                    ))}
+                </Row>
+              </React.Fragment>
+            ))}
+
+            <Divider />
+
+            <Row gutter={[16, 16]}>
+              {Object.values(CommonVictoryPoses)
+                .filter((v) => v.itemSource === ItemSource.CargoCrate)
+                .map((commonVictoryPose) => (
+                  <CommonVictoryPoseCard
+                    key={miner + commonVictoryPose.name}
+                    miner={miner}
+                    commonVictoryPose={commonVictoryPose}
+                  />
+                ))}
+            </Row>
+          </>
+        )}
+      </MinerPageLayout>
+      <Collapse
+        className="unselectable"
+        expandIconPosition="right"
+        defaultActiveKey={getOpenCategories(categories)}
+        onChange={(open) => updateOpenCategories(open, categories)}
+        expandIcon={(p) => (
+          <RightOutlined
+            style={{ marginTop: 16 }}
+            rotate={p.isActive ? 90 : undefined}
+          />
+        )}
+      >
+        <BoscoFrameworks
+          forceRender
+          key="cargo-bosco-frameworks"
+          frameworks={BoscoFrameworksList.filter(
+            (f) => f.itemSource === ItemSource.CargoCrate
+          )}
+          getProgress={getBoscoFrameworkProgress}
+        />
+      </Collapse>
+    </>
+  );
+}

--- a/src/pages/origin/LostPackPage.tsx
+++ b/src/pages/origin/LostPackPage.tsx
@@ -35,7 +35,10 @@ export default function LostPackPage() {
         (p) => lostPackArmorPaintjobs.includes(p.name)
       ).length;
 
-      return acquiredLostPackArmorPaintjobs / lostPackArmorPaintjobs.length;
+      return {
+        obtained: acquiredLostPackArmorPaintjobs,
+        total: lostPackArmorPaintjobs.length,
+      };
     },
     []
   );
@@ -50,7 +53,10 @@ export default function LostPackPage() {
         (p) => lostPackBoscoPaintjobs.includes(p.name)
       ).length;
 
-      return acquiredLostPackBoscoPaintjobs / lostPackBoscoPaintjobs.length;
+      return {
+        obtained: acquiredLostPackBoscoPaintjobs,
+        total: lostPackBoscoPaintjobs.length,
+      };
     },
     []
   );
@@ -74,10 +80,10 @@ export default function LostPackPage() {
         .anyOf(PickaxeUniquePartNames)
         .count();
       // Denominator: 6 Total Pickaxe Parts - 1 Paintjob Part = 5 Non-Paintjob Parts
-      return (
-        (acquiredLostPackPickaxes + acquiredUniques) /
-        (lostPackPickaxes.length * 5 + UniqueParts.length)
-      );
+      return {
+        obtained: acquiredLostPackPickaxes + acquiredUniques,
+        total: lostPackPickaxes.length * 5 + UniqueParts.length,
+      };
     },
     []
   );
@@ -96,7 +102,10 @@ export default function LostPackPage() {
         lostPackPickaxePaintjobs.includes(p.name)
       ).length;
       // 6 Total Pickaxe Parts - 1 Paintjob Part = 5 Remaining Parts
-      return acquiredLostPackPickaxePaintjobs / lostPackPickaxePaintjobs.length;
+      return {
+        obtained: acquiredLostPackPickaxePaintjobs,
+        total: lostPackPickaxePaintjobs.length,
+      };
     },
     []
   );
@@ -105,8 +114,11 @@ export default function LostPackPage() {
     (p) => p.source === ItemSource.LostPack
   ).map((p) => p.name);
 
-  const boscoCategories = ['lostpack-bocso-paintjobs']
-  const pickaxeCategories = ['lostpack-pickaxe-paintjobs', 'lostpack-pickaxe-parts']
+  const boscoCategories = ['lostpack-bocso-paintjobs'];
+  const pickaxeCategories = [
+    'lostpack-pickaxe-paintjobs',
+    'lostpack-pickaxe-parts',
+  ];
 
   return (
     <>

--- a/src/pages/origin/LostPackPage.tsx
+++ b/src/pages/origin/LostPackPage.tsx
@@ -69,7 +69,7 @@ export default function LostPackPage() {
         .and((p) => p.part !== 'Paintjob')
         .toArray();
       const lostPackPickaxes = Pickaxes.filter(
-        (p) => p.source === ItemSource.LostPack
+        (p) => p.itemSource === ItemSource.LostPack
       ).map((p) => p.name);
       const acquiredLostPackPickaxes = acquiredPickaxes.filter((p) =>
         lostPackPickaxes.includes(p.name)
@@ -96,7 +96,7 @@ export default function LostPackPage() {
         .and((p) => p.part === 'Paintjob')
         .toArray();
       const lostPackPickaxePaintjobs = Pickaxes.filter(
-        (p) => p.source === ItemSource.LostPack
+        (p) => p.itemSource === ItemSource.LostPack
       ).map((p) => p.name);
       const acquiredLostPackPickaxePaintjobs = acquiredPaintjobs.filter((p) =>
         lostPackPickaxePaintjobs.includes(p.name)
@@ -111,7 +111,7 @@ export default function LostPackPage() {
   );
 
   const lostPackPickaxePaintjobs: PickaxePaintjobName[] = Pickaxes.filter(
-    (p) => p.source === ItemSource.LostPack
+    (p) => p.itemSource === ItemSource.LostPack
   ).map((p) => p.name);
 
   const boscoCategories = ['lostpack-bocso-paintjobs'];
@@ -173,7 +173,7 @@ export default function LostPackPage() {
         <PickaxeParts
           forceRender
           key="lostpack-pickaxe-parts"
-          pickaxes={Pickaxes.filter((p) => p.source === ItemSource.LostPack)}
+          pickaxes={Pickaxes.filter((p) => p.itemSource === ItemSource.LostPack)}
           getProgress={getLostPackPickaxePartProgress}
         />
         <PickaxePaintjobs

--- a/src/pages/origin/LostPackPage.tsx
+++ b/src/pages/origin/LostPackPage.tsx
@@ -1,0 +1,176 @@
+import { RightOutlined } from '@ant-design/icons';
+import { Collapse, Row } from 'antd';
+import { useCallback } from 'react';
+import { ArmorPaintjobs } from 'data/armor';
+import { BoscoPaintjobs as BoscoPaintjobsList } from 'data/bosco';
+import { Miner } from 'data/miner';
+import {
+  Pickaxes,
+  PickaxePaintjobNames,
+  PickaxeSets,
+  PickaxeUniquePartNames,
+  UniqueParts,
+  PickaxePaintjobName,
+} from 'data/pickaxes';
+import { AppDatabase } from 'db/AppDatabase';
+import MinerPageLayout from 'pages/MinerPageLayout';
+import ArmorPaintjobCard from 'pages/armor/ArmorPaintjobCard';
+import BoscoPaintjobs from 'pages/bosco/BoscoPaintjobs';
+import PickaxePaintjobs from 'pages/pickaxes/PickaxePaintjobs';
+import PickaxeParts from 'pages/pickaxes/PickaxeParts';
+import { ItemSource } from 'types/itemSource';
+import { getOpenCategories, updateOpenCategories } from 'utils/localStorage';
+
+export default function LostPackPage() {
+  const getLostPackProgress = useCallback(
+    async (db: AppDatabase, miner: Miner) => {
+      const acquiredArmorPaintjobs = await db.armorPaintjobs
+        .where('miner')
+        .anyOf(miner)
+        .toArray();
+      const lostPackArmorPaintjobs = ArmorPaintjobs[miner]
+        .filter((p) => p.itemSource === ItemSource.LostPack)
+        .map((p) => p.name);
+      const acquiredLostPackArmorPaintjobs = acquiredArmorPaintjobs.filter(
+        (p) => lostPackArmorPaintjobs.includes(p.name)
+      ).length;
+
+      return acquiredLostPackArmorPaintjobs / lostPackArmorPaintjobs.length;
+    },
+    []
+  );
+
+  const getLostPackBoscoPaintjobProgress = useCallback(
+    async (db: AppDatabase) => {
+      const acquiredBoscoPaintjobs = await db.boscoPaintjobs.toArray();
+      const lostPackBoscoPaintjobs = BoscoPaintjobsList.filter(
+        (p) => p.itemSource === ItemSource.LostPack
+      ).map((p) => p.name);
+      const acquiredLostPackBoscoPaintjobs = acquiredBoscoPaintjobs.filter(
+        (p) => lostPackBoscoPaintjobs.includes(p.name)
+      ).length;
+
+      return acquiredLostPackBoscoPaintjobs / lostPackBoscoPaintjobs.length;
+    },
+    []
+  );
+
+  const getLostPackPickaxePartProgress = useCallback(
+    async (db: AppDatabase) => {
+      const acquiredPickaxes = await db.pickaxes
+        .where('name')
+        .anyOf(PickaxeSets)
+        .and((p) => p.part !== 'Paintjob')
+        .toArray();
+      const lostPackPickaxes = Pickaxes.filter(
+        (p) => p.source === ItemSource.LostPack
+      ).map((p) => p.name);
+      const acquiredLostPackPickaxes = acquiredPickaxes.filter((p) =>
+        lostPackPickaxes.includes(p.name)
+      ).length;
+
+      const acquiredUniques = await db.pickaxeUniques
+        .where('name')
+        .anyOf(PickaxeUniquePartNames)
+        .count();
+      // Denominator: 6 Total Pickaxe Parts - 1 Paintjob Part = 5 Non-Paintjob Parts
+      return (
+        (acquiredLostPackPickaxes + acquiredUniques) /
+        (lostPackPickaxes.length * 5 + UniqueParts.length)
+      );
+    },
+    []
+  );
+
+  const getLostPackPickaxePaintjobProgress = useCallback(
+    async (db: AppDatabase) => {
+      const acquiredPaintjobs = await db.pickaxes
+        .where('name')
+        .anyOf(PickaxePaintjobNames)
+        .and((p) => p.part === 'Paintjob')
+        .toArray();
+      const lostPackPickaxePaintjobs = Pickaxes.filter(
+        (p) => p.source === ItemSource.LostPack
+      ).map((p) => p.name);
+      const acquiredLostPackPickaxePaintjobs = acquiredPaintjobs.filter((p) =>
+        lostPackPickaxePaintjobs.includes(p.name)
+      ).length;
+      // 6 Total Pickaxe Parts - 1 Paintjob Part = 5 Remaining Parts
+      return acquiredLostPackPickaxePaintjobs / lostPackPickaxePaintjobs.length;
+    },
+    []
+  );
+
+  const lostPackPickaxePaintjobs: PickaxePaintjobName[] = Pickaxes.filter(
+    (p) => p.source === ItemSource.LostPack
+  ).map((p) => p.name);
+
+  const boscoCategories = ['lostpack-bocso-paintjobs']
+  const pickaxeCategories = ['lostpack-pickaxe-paintjobs', 'lostpack-pickaxe-parts']
+
+  return (
+    <>
+      <MinerPageLayout category="LostPack" getProgress={getLostPackProgress}>
+        {(miner) => (
+          <Row gutter={[16, 16]}>
+            {ArmorPaintjobs[miner]
+              .filter((p) => p.itemSource === ItemSource.LostPack)
+              .map((paintjob) => (
+                <ArmorPaintjobCard
+                  key={miner + paintjob.name}
+                  miner={miner}
+                  paintjob={paintjob}
+                />
+              ))}
+          </Row>
+        )}
+      </MinerPageLayout>
+      <Collapse
+        className="unselectable"
+        expandIconPosition="right"
+        defaultActiveKey={getOpenCategories(boscoCategories)}
+        onChange={(open) => updateOpenCategories(open, boscoCategories)}
+        expandIcon={(p) => (
+          <RightOutlined
+            style={{ marginTop: 16 }}
+            rotate={p.isActive ? 90 : undefined}
+          />
+        )}
+      >
+        <BoscoPaintjobs
+          forceRender
+          key="lostpack-bocso-paintjobs"
+          paintjobs={BoscoPaintjobsList.filter(
+            (p) => p.itemSource === ItemSource.LostPack
+          )}
+          getProgress={getLostPackBoscoPaintjobProgress}
+        />
+      </Collapse>
+      <Collapse
+        className="unselectable"
+        expandIconPosition="right"
+        defaultActiveKey={getOpenCategories(pickaxeCategories)}
+        onChange={(open) => updateOpenCategories(open, pickaxeCategories)}
+        expandIcon={(p) => (
+          <RightOutlined
+            style={{ marginTop: 16 }}
+            rotate={p.isActive ? 90 : undefined}
+          />
+        )}
+      >
+        <PickaxeParts
+          forceRender
+          key="lostpack-pickaxe-parts"
+          pickaxes={Pickaxes.filter((p) => p.source === ItemSource.LostPack)}
+          getProgress={getLostPackPickaxePartProgress}
+        />
+        <PickaxePaintjobs
+          forceRender
+          key="lostpack-pickaxe-paintjobs"
+          paintjobs={lostPackPickaxePaintjobs}
+          getProgress={getLostPackPickaxePaintjobProgress}
+        />
+      </Collapse>
+    </>
+  );
+}

--- a/src/pages/origin/MatrixCorePage.tsx
+++ b/src/pages/origin/MatrixCorePage.tsx
@@ -93,21 +93,21 @@ export default function MatrixCorePage() {
                   />
                 ))}
               </Row>
-              <Divider />
-              <Row gutter={[16, 16]}>
-                {MatrixWeaponPaintjobs.map((paintjob) => (
-                  <MatrixWeaponPaintjobCard
-                    key={miner + paintjob.name + paintjob.id}
-                    miner={miner}
-                    weaponPaintjob={paintjob as MatrixWeaponPaintjob}
-                  />
-                ))}
-              </Row>
             </React.Fragment>
           ))}
 
           <Divider />
+          <Row gutter={[16, 16]}>
+            {MatrixWeaponPaintjobs.map((paintjob) => (
+              <MatrixWeaponPaintjobCard
+                key={miner + paintjob.name + paintjob.id}
+                miner={miner}
+                weaponPaintjob={paintjob as MatrixWeaponPaintjob}
+              />
+            ))}
+          </Row>
 
+          <Divider />
           <Row gutter={[16, 16]}>
             {Object.values(MatrixVictoryPoses[miner]).map(
               (matrixVictoryPose) => (
@@ -120,12 +120,10 @@ export default function MatrixCorePage() {
             )}
           </Row>
 
-          <>
-            <CosmeticHeadwears miner={miner}></CosmeticHeadwears>
-            <CosmeticMoustaches miner={miner}></CosmeticMoustaches>
-            <CosmeticBeards miner={miner}></CosmeticBeards>
-            <CosmeticSideburns miner={miner}></CosmeticSideburns>
-          </>
+          <CosmeticHeadwears miner={miner}></CosmeticHeadwears>
+          <CosmeticMoustaches miner={miner}></CosmeticMoustaches>
+          <CosmeticBeards miner={miner}></CosmeticBeards>
+          <CosmeticSideburns miner={miner}></CosmeticSideburns>
         </>
       )}
     </MinerPageLayout>

--- a/src/pages/origin/MatrixCorePage.tsx
+++ b/src/pages/origin/MatrixCorePage.tsx
@@ -55,16 +55,18 @@ export default function MatrixCorePage() {
         .filter((item) => item.isForged)
         .count();
 
-      return (
-        (forgedOverclocks +
+      return {
+        obtained:
+          forgedOverclocks +
           acquiredMatrixPaintjobs +
           acquiredMatrixVictoryPoses +
-          acquiredCosmetics) /
-        (totalOverclocks +
+          acquiredCosmetics,
+        total:
+          totalOverclocks +
           totalMatrixPaintjobs +
           totalMatrixVictoryPoses +
-          totalCosmetics)
-      );
+          totalCosmetics,
+      };
     },
     []
   );

--- a/src/pages/origin/MatrixCorePage.tsx
+++ b/src/pages/origin/MatrixCorePage.tsx
@@ -1,0 +1,131 @@
+import { Divider, Row } from 'antd';
+import React, { useCallback } from 'react';
+import WeaponDivider from 'components/WeaponDivider';
+import { CosmeticMatrixItems } from 'data/cosmetics';
+import { Miner } from 'data/miner';
+import { Overclocks } from 'data/overclocks';
+import { MatrixVictoryPoses } from 'data/victoryPoses';
+import {
+  MatrixWeaponPaintjobs,
+  MatrixWeaponPaintjob,
+} from 'data/weaponPaintjobs';
+import { MinerWeapon, MinerWeapons } from 'data/weapons';
+import { AppDatabase } from 'db/AppDatabase';
+import MinerPageLayout from 'pages/MinerPageLayout';
+import {
+  CosmeticHeadwears,
+  CosmeticMoustaches,
+  CosmeticBeards,
+  CosmeticSideburns,
+} from 'pages/cosmetics/CosmeticsPage';
+import OverclockCard from 'pages/overclocks/OverclockCard';
+import MatrixVictoryPoseCard from 'pages/victoryPoses/MatrixVictoryPoseCard';
+import MatrixWeaponPaintjobCard from 'pages/weaponPaintjobs/MatrixWeaponPaintjobCard';
+import { Overclock } from 'types/overclock';
+
+export default function MatrixCorePage() {
+  const getMatrixCoreProgress = useCallback(
+    async (db: AppDatabase, miner: Miner) => {
+      const forgedOverclocks = await db.overclocks
+        .where('weapon')
+        .anyOf(MinerWeapons[miner as Miner])
+        .filter((o) => o.isForged)
+        .count();
+      const totalOverclocks = Object.values(Overclocks[miner as Miner]).flat()
+        .length;
+
+      const acquiredMatrixPaintjobs = await db.matrixWeaponPaintjobs
+        .where('miner')
+        .anyOf(miner)
+        .filter((paintjob) => paintjob.isForged)
+        .count();
+      const totalMatrixPaintjobs = MatrixWeaponPaintjobs.length;
+
+      const totalMatrixVictoryPoses = MatrixVictoryPoses[miner].length;
+      const acquiredMatrixVictoryPoses = await db.matrixVictoryPoses
+        .where('miner')
+        .anyOf(miner)
+        .filter((pose) => pose.isForged)
+        .count();
+
+      const totalCosmetics = CosmeticMatrixItems.length;
+      const acquiredCosmetics = await db.cosmeticMatrixItems
+        .where('miner')
+        .anyOf(miner)
+        .filter((item) => item.isForged)
+        .count();
+
+      return (
+        (forgedOverclocks +
+          acquiredMatrixPaintjobs +
+          acquiredMatrixVictoryPoses +
+          acquiredCosmetics) /
+        (totalOverclocks +
+          totalMatrixPaintjobs +
+          totalMatrixVictoryPoses +
+          totalCosmetics)
+      );
+    },
+    []
+  );
+
+  return (
+    <MinerPageLayout category="MatrixCores" getProgress={getMatrixCoreProgress}>
+      {(miner) => (
+        <>
+          {MinerWeapons[miner].map((weapon) => (
+            <React.Fragment key={weapon}>
+              <WeaponDivider weapon={weapon} />
+              <Row gutter={[16, 16]}>
+                {Object.values(
+                  (Overclocks as Record<
+                    Miner,
+                    Record<MinerWeapon<Miner>, Overclock[]>
+                  >)[miner][weapon]
+                ).map((overclock) => (
+                  <OverclockCard
+                    key={overclock.name}
+                    overclock={overclock}
+                    miner={miner}
+                    weapon={weapon as MinerWeapon<Miner>}
+                  />
+                ))}
+              </Row>
+              <Divider />
+              <Row gutter={[16, 16]}>
+                {MatrixWeaponPaintjobs.map((paintjob) => (
+                  <MatrixWeaponPaintjobCard
+                    key={miner + paintjob.name + paintjob.id}
+                    miner={miner}
+                    weaponPaintjob={paintjob as MatrixWeaponPaintjob}
+                  />
+                ))}
+              </Row>
+            </React.Fragment>
+          ))}
+
+          <Divider />
+
+          <Row gutter={[16, 16]}>
+            {Object.values(MatrixVictoryPoses[miner]).map(
+              (matrixVictoryPose) => (
+                <MatrixVictoryPoseCard
+                  key={miner + matrixVictoryPose.name}
+                  miner={miner}
+                  victoryPose={matrixVictoryPose}
+                />
+              )
+            )}
+          </Row>
+
+          <>
+            <CosmeticHeadwears miner={miner}></CosmeticHeadwears>
+            <CosmeticMoustaches miner={miner}></CosmeticMoustaches>
+            <CosmeticBeards miner={miner}></CosmeticBeards>
+            <CosmeticSideburns miner={miner}></CosmeticSideburns>
+          </>
+        </>
+      )}
+    </MinerPageLayout>
+  );
+}

--- a/src/pages/overclocks/OverclocksPage.tsx
+++ b/src/pages/overclocks/OverclocksPage.tsx
@@ -13,9 +13,10 @@ export default function OverclocksPage() {
       .anyOf(MinerWeapons[miner as Miner])
       .filter((o) => o.isForged)
       .count();
-    return (
-      forgedOverclocks / Object.values(Overclocks[miner as Miner]).flat().length
-    );
+    return {
+      obtained: forgedOverclocks,
+      total: Object.values(Overclocks[miner as Miner]).flat().length,
+    };
   }, []);
   return (
     <MinerPageLayout category="Overclocks" getProgress={getProgress}>

--- a/src/pages/pickaxes/PaintjobCard.tsx
+++ b/src/pages/pickaxes/PaintjobCard.tsx
@@ -1,10 +1,11 @@
-import { Badge, Card, Col } from 'antd';
+import { Badge, Card, Col, Row } from 'antd';
 import { useCallback } from 'react';
 import { MinerColor } from 'data/miner';
-import { PickaxePaintjobNames, PickaxeParts } from 'data/pickaxes';
+import { Pickaxe, PickaxePaintjobNames, PickaxeParts, Pickaxes } from 'data/pickaxes';
 import './PaintjobCard.css';
 import useDB from 'db/useDB';
 import useSuspendedLiveQuery from 'db/useSuspendedLiveQuery';
+import ItemOrigin from 'pages/ItemOrigin';
 import PaintjobIcon from './PaintjobIcon';
 
 const accentColor = MinerColor.Scout;
@@ -42,6 +43,11 @@ export default function PaintjobCard(props: {
           }}
         >
           <PaintjobIcon paintjob={props.paintjob} />
+          <Row justify="end">
+            <Col>
+              <ItemOrigin item={Pickaxes.find((pick) => pick.name === props.paintjob) as Pickaxe} acquired={query && true} />
+            </Col>
+          </Row>
         </Card>
       </Badge.Ribbon>
     </Col>

--- a/src/pages/pickaxes/PickaxeCard.tsx
+++ b/src/pages/pickaxes/PickaxeCard.tsx
@@ -138,7 +138,7 @@ export default function PickaxeCard(props: { pickaxe: Pickaxe }) {
 
   // Returns the appropriate icon based on the current pickaxe's source.
   const iconSrc = useMemo(() => {
-    switch (props.pickaxe.source) {
+    switch (props.pickaxe.itemSource) {
       case ItemSource.Assignment:
         return Assignment;
       case ItemSource.DLC:
@@ -150,7 +150,7 @@ export default function PickaxeCard(props: { pickaxe: Pickaxe }) {
       default:
         return Assignment;
     }
-  }, [props.pickaxe.source]);
+  }, [props.pickaxe.itemSource]);
 
   return (
     <Col xxl={6} xl={8} lg={12} md={12} sm={12} xs={24}>
@@ -160,12 +160,12 @@ export default function PickaxeCard(props: { pickaxe: Pickaxe }) {
           <div style={{ whiteSpace: 'break-spaces' }}>
             {props.pickaxe.name}
             <Image
-              alt={`${props.pickaxe.name} is acquired via ${props.pickaxe.source}`}
+              alt={`${props.pickaxe.name} is acquired via ${props.pickaxe.itemSource}`}
               src={iconSrc}
               style={{
                 filter: isComplete
                   ? `grayscale(1) invert(1) ${
-                      props.pickaxe.source === 'Lost Pack'
+                      props.pickaxe.itemSource === 'Lost Pack'
                         ? 'brightness(0)'
                         : ''
                     }`
@@ -197,7 +197,7 @@ export default function PickaxeCard(props: { pickaxe: Pickaxe }) {
             <Tooltip
               destroyTooltipOnHide
               placement="bottom"
-              title={`Obtained via ${props.pickaxe.source}${
+              title={`Obtained via ${props.pickaxe.itemSource}${
                 props.pickaxe.assignmentRank
                   ? ' at Rank ' + props.pickaxe.assignmentRank
                   : ''

--- a/src/pages/pickaxes/PickaxePaintjobs.tsx
+++ b/src/pages/pickaxes/PickaxePaintjobs.tsx
@@ -2,8 +2,9 @@ import { Card, Collapse, CollapsePanelProps, Row } from 'antd';
 import { PaintPickaxeIcon } from 'assets/other';
 import Image from 'components/Image';
 import { PickaxePaintjobName } from 'data/pickaxes';
+import { ProgressQuery } from 'types/progress';
 import PaintjobCard from './PaintjobCard';
-import PickaxeProgressBar, { ProgressQuery } from './PickaxeProgressBar';
+import PickaxeProgressBar from './PickaxeProgressBar';
 
 const { Panel } = Collapse;
 const { Meta } = Card;

--- a/src/pages/pickaxes/PickaxePaintjobs.tsx
+++ b/src/pages/pickaxes/PickaxePaintjobs.tsx
@@ -1,7 +1,7 @@
 import { Card, Collapse, CollapsePanelProps, Row } from 'antd';
 import { PaintPickaxeIcon } from 'assets/other';
 import Image from 'components/Image';
-import { PickaxePaintjobNames } from 'data/pickaxes';
+import { PickaxePaintjobName } from 'data/pickaxes';
 import PaintjobCard from './PaintjobCard';
 import PickaxeProgressBar, { ProgressQuery } from './PickaxeProgressBar';
 
@@ -11,7 +11,7 @@ const { Meta } = Card;
 export default function PickaxePaintjobs(
   props: {
     getProgress: ProgressQuery;
-    paintjobs: typeof PickaxePaintjobNames;
+    paintjobs: PickaxePaintjobName[];
   } & Omit<CollapsePanelProps, 'key' | 'header'>
 ) {
   const { getProgress, paintjobs, ...panelProps } = props;

--- a/src/pages/pickaxes/PickaxeParts.tsx
+++ b/src/pages/pickaxes/PickaxeParts.tsx
@@ -2,8 +2,9 @@ import { Card, Collapse, CollapsePanelProps, Row } from 'antd';
 import { PickaxeIcon } from 'assets/other/';
 import Image from 'components/Image';
 import { Pickaxe, UniqueParts } from 'data/pickaxes';
+import { ProgressQuery } from 'types/progress';
 import PickaxeCard from './PickaxeCard';
-import PickaxeProgressBar, { ProgressQuery } from './PickaxeProgressBar';
+import PickaxeProgressBar from './PickaxeProgressBar';
 import UniquePartCard from './UniquePartCard';
 
 const { Panel } = Collapse;

--- a/src/pages/pickaxes/PickaxeProgressBar.tsx
+++ b/src/pages/pickaxes/PickaxeProgressBar.tsx
@@ -1,11 +1,9 @@
 import { Image, Progress, Tooltip } from 'antd';
 import { memo, useEffect } from 'react';
 import { RockAndStone } from 'assets/other';
-import type { AppDatabase } from 'db/AppDatabase';
 import useDB from 'db/useDB';
 import useSuspendedLiveQuery from 'db/useSuspendedLiveQuery';
-
-export type ProgressQuery = (db: AppDatabase) => Promise<number>;
+import { ProgressQuery } from 'types/progress';
 
 export default memo(function PickaxeProgressBar({
   barColor,
@@ -17,8 +15,8 @@ export default memo(function PickaxeProgressBar({
   getProgress: ProgressQuery;
 }) {
   const db = useDB();
-  const progress = useSuspendedLiveQuery(() => getProgress(db), []);
-  const progressPercentage = Math.round((progress || 0) * 100);
+  const { obtained, total } = useSuspendedLiveQuery(() => getProgress(db), []);
+  const progressPercentage = Math.floor((obtained / total || 0) * 100);
 
   useEffect(() => {
     gtag('event', 'progress', {

--- a/src/pages/pickaxes/PickaxeProgressBar.tsx
+++ b/src/pages/pickaxes/PickaxeProgressBar.tsx
@@ -44,7 +44,7 @@ export default memo(function PickaxeProgressBar({
             />
           </Tooltip>
         ) : (
-          `${percent}%`
+          `${percent}% (${obtained}/${total})`
         )
       }
     />

--- a/src/pages/pickaxes/PickaxesPage.tsx
+++ b/src/pages/pickaxes/PickaxesPage.tsx
@@ -25,10 +25,10 @@ export default function PickaxesPage() {
       .anyOf(PickaxeUniquePartNames)
       .count();
     // Denominator: 6 Total Pickaxe Parts - 1 Paintjob Part = 5 Non-Paintjob Parts
-    return (
-      (acquiredPickaxes + acquiredUniques) /
-      (PickaxeSets.length * 5 + PickaxeUniquePartNames.length)
-    );
+    return {
+      obtained: acquiredPickaxes + acquiredUniques,
+      total: PickaxeSets.length * 5 + PickaxeUniquePartNames.length,
+    };
   }, []);
 
   /** Get total count for all pickaxe Paintjob parts ONLY. */
@@ -39,7 +39,10 @@ export default function PickaxesPage() {
       .and((p) => p.part === 'Paintjob')
       .count();
     // 6 Total Pickaxe Parts - 1 Paintjob Part = 5 Remaining Parts
-    return acquiredPaintjobs / PickaxePaintjobNames.length;
+    return {
+      obtained: acquiredPaintjobs,
+      total: PickaxePaintjobNames.length,
+    };
   }, []);
 
   const categories = ['pickaxe-parts', 'pickaxe-paintjobs'];

--- a/src/pages/pickaxes/PickaxesPage.tsx
+++ b/src/pages/pickaxes/PickaxesPage.tsx
@@ -66,7 +66,7 @@ export default function PickaxesPage() {
       <PickaxePaintjobs
         forceRender
         key="pickaxe-paintjobs"
-        paintjobs={PickaxePaintjobNames}
+        paintjobs={Object.values(PickaxePaintjobNames)}
         getProgress={getPaintjobProgress}
       />
     </Collapse>

--- a/src/pages/victoryPoses/VictoryPosesPage.tsx
+++ b/src/pages/victoryPoses/VictoryPosesPage.tsx
@@ -21,10 +21,10 @@ export default function VictoryPosePage() {
       .where('miner')
       .anyOf(miner)
       .count();
-    return (
-      (acquiredMatrixVictoryPoses + acquiredCommonVictoryPoses) /
-      (matrixVictoryPoses.length + commonVictoryPoses.length)
-    );
+    return {
+      obtained: acquiredMatrixVictoryPoses + acquiredCommonVictoryPoses,
+      total: matrixVictoryPoses.length + commonVictoryPoses.length,
+    };
   }, []);
 
   return (

--- a/src/pages/weaponPaintjobs/WeaponPaintjobsPage.tsx
+++ b/src/pages/weaponPaintjobs/WeaponPaintjobsPage.tsx
@@ -36,7 +36,10 @@ export default function WeaponPaintjobPage() {
       UniqueWeaponPaintjobs.length *
         Object.values(MinerWeapons[miner as Miner]).length +
       CommonWeaponPaintjobs.length;
-    return num_acquired / total_number;
+    return {
+      obtained: num_acquired,
+      total: total_number,
+    };
   }, []);
 
   return (

--- a/src/types/progress.ts
+++ b/src/types/progress.ts
@@ -1,0 +1,14 @@
+import { Miner } from 'data/miner';
+import { AppDatabase } from 'db/AppDatabase';
+
+export type ProgressInfo = {
+  obtained: number;
+  total: number;
+};
+
+export type MinerProgressQuery = (
+  db: AppDatabase,
+  miner: Miner
+) => Promise<ProgressInfo>;
+
+export type ProgressQuery = (db: AppDatabase) => Promise<ProgressInfo>;


### PR DESCRIPTION
Add a total progress on the bottom overall progress bar that does not only show the % of all items, but also the actual number of acquired items out of all total items.

Also, add 3 tabs that bundle all matrix core, lost pack and cargo crate items respectively.