### PR TITLE
Fix pickaxe paintjobs not being recognized

### DIFF
--- a/src/hooks/analyze/useGetPickaxePartsFromSaveFile.ts
+++ b/src/hooks/analyze/useGetPickaxePartsFromSaveFile.ts
@@ -21,6 +21,7 @@ export default function useGetPickaxePartsFromSaveFile(): (
             handle
             shaft
             pommel
+            paint_job
           }
         }
       }
@@ -83,6 +84,16 @@ export default function useGetPickaxePartsFromSaveFile(): (
           acquiredPickaxeParts.push({
             name: pickaxePartSet.name,
             component: 'POMMEL',
+          });
+        }
+
+        if (
+          pickaxePartSet.saveIds.paint_job !== null &&
+          unlockedPickaxeParts.includes(pickaxePartSet.saveIds.paint_job)
+        ) {
+          acquiredPickaxeParts.push({
+            name: pickaxePartSet.name,
+            component: 'PAINT_JOB',
           });
         }
       }


### PR DESCRIPTION
I have not dig thought the entire codebase, not entirely sure how the database works but I believe this is not a breaking change and it should be enough to have drg-completionist recognize pickaxe paintjobs correctly.